### PR TITLE
url_callback config + specs

### DIFF
--- a/lib/locasms/rest_client.rb
+++ b/lib/locasms/rest_client.rb
@@ -61,7 +61,7 @@ module LocaSMS
     #
     # @see https://github.com/mcorp/locasms/wiki/A-API-de-envio#lista-das-a%C3%A7%C3%B5es-dispon%C3%ADveis List of avaiable actions
     def params_for(action, params={})
-      { action: action }.merge(base_params).merge(params)
+      { action: action }.merge(base_params).merge(params).select {|k, v| v }
     end
 
     # Parses a result trying to get it in json

--- a/spec/lib/locasms/client_spec.rb
+++ b/spec/lib/locasms/client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe LocaSMS::Client do
   let(:rest_client) { 'rest_client mock' }
-  subject { LocaSMS::Client.new :login, :password, rest_client: rest_client }
+  subject { LocaSMS::Client.new :login, :password, rest_client: rest_client, callback: nil }
 
   describe '::ENDPOINT' do
     let(:domain) { LocaSMS::Client::DOMAIN }
@@ -38,7 +38,7 @@ describe LocaSMS::Client do
 
       expect(rest_client).to receive(:get)
         .once
-        .with(:sendsms, msg: 'given message', numbers:'XXX')
+        .with(:sendsms, msg: 'given message', numbers:'XXX', url_callback: nil)
         .and_return({})
 
       subject.deliver 'given message', :a, :b, :c
@@ -53,6 +53,40 @@ describe LocaSMS::Client do
       expect(rest_client).to receive(:get).never
 
       expect { subject.deliver('given message', :a, :b, :c) }.to raise_error(LocaSMS::Exception)
+    end
+
+    context 'with callback option' do
+      context 'callback given as arg to #deliver' do
+        it 'uses specific callback' do
+          expect(subject).to receive(:numbers)
+            .once
+            .with([:a, :b, :c])
+            .and_return('XXX')
+
+          expect(rest_client).to receive(:get)
+            .once
+            .with(:sendsms, msg: 'given message', numbers:'XXX', url_callback: 'something')
+            .and_return({})
+
+          subject.deliver 'given message', :a, :b, :c, url_callback: 'something'
+        end
+      end
+
+      it 'uses default callback' do
+        client = LocaSMS::Client.new :login, :password, rest_client: rest_client, url_callback: 'default'
+
+        expect(client).to receive(:numbers)
+          .once
+          .with([:a, :b, :c])
+          .and_return('XXX')
+
+        expect(rest_client).to receive(:get)
+          .once
+          .with(:sendsms, msg: 'given message', numbers:'XXX', url_callback: 'default')
+          .and_return({})
+
+        client.deliver 'given message', :a, :b, :c
+      end
     end
   end
 
@@ -70,7 +104,7 @@ describe LocaSMS::Client do
 
       expect(rest_client).to receive(:get)
         .once
-        .with(:sendsms, msg: 'given message', numbers:'XXX', jobdate: 'date', jobtime: 'time')
+        .with(:sendsms, msg: 'given message', numbers:'XXX', jobdate: 'date', jobtime: 'time', url_callback: nil)
         .and_return({})
 
       subject.deliver_at 'given message', :datetime, :a, :b, :c
@@ -90,6 +124,50 @@ describe LocaSMS::Client do
       expect(rest_client).to receive(:get).never
 
       expect { subject.deliver_at('given message', :datetime, :a, :b, :c) }.to raise_error(LocaSMS::Exception)
+    end
+
+    context 'with callback option' do
+      context 'callback given as arg to #deliver' do
+        it 'uses specific callback' do
+          expect(subject).to receive(:numbers)
+            .once
+            .with([:a, :b, :c])
+            .and_return('XXX')
+
+          expect(LocaSMS::Helpers::DateTimeHelper).to receive(:split)
+            .once
+            .with(:datetime)
+            .and_return(%w[date time])
+
+          expect(rest_client).to receive(:get)
+            .once
+            .with(:sendsms, msg: 'given message', numbers:'XXX', jobdate: 'date', jobtime: 'time', url_callback: 'something')
+            .and_return({})
+
+          subject.deliver_at 'given message', :datetime, :a, :b, :c, url_callback: 'something'
+        end
+      end
+
+      it 'uses default callback' do
+        client = LocaSMS::Client.new :login, :password, rest_client: rest_client, url_callback: 'default'
+
+        expect(client).to receive(:numbers)
+          .once
+          .with([:a, :b, :c])
+          .and_return('XXX')
+
+        expect(LocaSMS::Helpers::DateTimeHelper).to receive(:split)
+          .once
+          .with(:datetime)
+          .and_return(%w[date time])
+
+        expect(rest_client).to receive(:get)
+          .once
+          .with(:sendsms, msg: 'given message', numbers:'XXX', jobdate: 'date', jobtime: 'time', url_callback: 'default')
+          .and_return({})
+
+        client.deliver_at 'given message', :datetime, :a, :b, :c
+      end
     end
   end
 

--- a/spec/lib/locasms/rest_client_spec.rb
+++ b/spec/lib/locasms/rest_client_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe LocaSMS::RestClient do
+  let(:callback) { 'http://example.com/callback' }
+  let(:params) { { lgn: 'LOGIN', pwd: 'PASSWORD', url_callback: callback } }
+
   describe '.initialize' do
     context 'When giving proper initialization parameters' do
       subject { LocaSMS::RestClient.new :url, :params }
@@ -11,7 +14,6 @@ describe LocaSMS::RestClient do
 
   describe '#get' do
     let(:action) { 'sendsms' }
-    let(:params) { { lgn: 'LOGIN', pwd: 'PASSWORD' } }
     let(:body) { '{"status":1,"data":28,"msg":null}' }
     subject { LocaSMS::RestClient.new(action, params) }
 
@@ -25,10 +27,17 @@ describe LocaSMS::RestClient do
   end
 
   describe '#params_for' do
-    subject { LocaSMS::RestClient.new :url, { b1: 'X' } }
+    subject { LocaSMS::RestClient.new :url, params }
 
-    it { expect(subject.params_for(:action)).to eq({action: :action, b1: 'X'}) }
-    it { expect(subject.params_for(:action, p1: 10)).to eq({action: :action, b1: 'X', p1: 10}) }
+    it { expect(subject.params_for(:action)).to eq({action: :action}.merge(params)) }
+    it { expect(subject.params_for(:action, p1: 10)).to eq({action: :action, p1: 10}.merge(params)) }
+
+    context 'callback nil' do
+      let(:callback) { nil }
+      it 'should not be in params' do
+        expect(subject.params_for(:action)).to eq({action: :action, lgn: 'LOGIN', pwd: 'PASSWORD'})
+      end
+    end
   end
 
   describe '#parse_response' do


### PR DESCRIPTION
Config as global fallback:
```
cli = LocaSMS::Client.new 'LOGIN', 'PASSWORD', url_callback: 'http://example.com/callback
```

Per request callback:
```
cli.deliver 'my message', '1199998888,5500002222', url_callback: 'http://unique.com/callback'

cli.deliver_at 'my message', '2013-10-12 20:33:00', '1155559999', url_callback: 'http://another.com/callback'
```

https://github.com/mcorp/locasms/issues/16