### PR TITLE
Adicionando versão 2.6 do Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.6
   - 2.5
   - 2.4
   - 2.3
@@ -7,4 +8,4 @@ rvm:
   - 2.1
 env:
   - TRAVIS=true
-before_install: gem install bundler -v 1.15.4
+before_install: gem install bundler -v 1.17.2

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.0'
+  spec.required_ruby_version = '~> 2.1'
 
   spec.add_dependency 'multi_json', '~> 1.0'
 


### PR DESCRIPTION
- [x] Adicionando ruby 2.6 a lista de versões do ruby testadas
- [x] Atualizando o `bundler` usado no travis para 1.17.2
- [x] Atualizando a versão mínima suportada na gem para 2.1