### PR TITLE
Upgrade gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - 2.4
   - 2.3
   - 2.2
-  - 2.1
 env:
   - TRAVIS=true
 before_install: gem install bundler -v 1.17.2

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '~> 2.2'
 
   spec.add_dependency 'multi_json', '~> 1.13'
 

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'multi_json', '~> 1.13'
 
-  spec.add_development_dependency 'bundler',   '~> 1.15'
+  spec.add_development_dependency 'bundler',   '~> 1.17'
   spec.add_development_dependency 'rake',      '~> 12.1'
 
   # test stuff

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_dependency 'multi_json', '~> 1.0'
+  spec.add_dependency 'multi_json', '~> 1.13'
 
   spec.add_development_dependency 'bundler',   '~> 1.15'
   spec.add_development_dependency 'rake',      '~> 12.1'

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.4'
 
   # for code coverage
-  spec.add_development_dependency 'simplecov', '~> 0.15'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
 end

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake',      '~> 13.0'
 
   # test stuff
-  spec.add_development_dependency 'rspec',     '~> 3.6'
+  spec.add_development_dependency 'rspec',     '~> 3.9'
   spec.add_development_dependency 'timecop',   '~> 0.9'
 
   # for documentation

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '~> 1.13'
 
   spec.add_development_dependency 'bundler',   '~> 1.17'
-  spec.add_development_dependency 'rake',      '~> 12.1'
+  spec.add_development_dependency 'rake',      '~> 13.0'
 
   # test stuff
   spec.add_development_dependency 'rspec',     '~> 3.6'

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   # for documentation
   spec.add_development_dependency 'yard',      '~> 0.9'
-  spec.add_development_dependency 'redcarpet', '~> 3.4'
+  spec.add_development_dependency 'redcarpet', '~> 3.5'
 
   # for code coverage
   spec.add_development_dependency 'simplecov', '~> 0.17'


### PR DESCRIPTION
- Upgrade multi_json from 1.0 to 1.13
- Upgrade bundler from 1.15 to 1.17
- Upgrade simplecov from 0.15 to 0.17
- Upgrade rake from 12.1 to 13.0
- Upgrade rspec from 3.6 to 3.9
- Upgrade redcarpet from 3.4 to 3.5
- Remove oldest ruby version (2.1)