### PR TITLE
Remove oldest and add newest ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: ruby
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4
-  - 2.3
-  - 2.2
 env:
   - TRAVIS=true
-before_install:
-  - gem install bundler -v 1.17.2
-  - gem install simplecov -v 0.17.1
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.2'
+  spec.required_ruby_version = '~> 2.4'
 
   spec.add_dependency 'multi_json', '~> 1.13'
 
-  spec.add_development_dependency 'bundler',   '~> 1.17'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake',      '~> 13.0'
 
   # test stuff
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.5'
 
   # for code coverage
-  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'simplecov', '~> 0.18'
 end


### PR DESCRIPTION
Upgrade rubies support as [ruby-lang](https://www.ruby-lang.org/en/downloads/).

Remove unsupported versions:
- 2.2
- 2.3

Add new supported version:
- 2.7
