### PR TITLE
Bumps rubocop (and dependencies)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0', jruby, jruby-head]
+        ruby: [2.6, 2.7, '3.0', jruby, jruby-head]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Cliente para disparo de SMS, regular e Short Code, através da LocaSMS/SMS Plataforma'
   spec.homepage      = 'https://github.com/mcorp/locasms'
   spec.license       = 'MIT'
+  spec.metadata      = { 'rubygems_mfa_required' => 'true' }
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 2.5'

--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -38,8 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.18'
 
   # for code quality
-  spec.add_development_dependency 'rubocop', '~> 1.22'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.11'
+  spec.add_development_dependency 'rubocop', '~> 1.36'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.15'
   spec.add_development_dependency 'rubocop-rake', '~> 0.6'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.5'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.13'
 end

--- a/spec/lib/locasms/client_spec.rb
+++ b/spec/lib/locasms/client_spec.rb
@@ -143,23 +143,25 @@ describe LocaSMS::Client do # rubocop:disable RSpec/FilePath
   end
 
   context 'when receive all campaign based methods' do
-    def check_for(method)
-      rest_method = {
-        campaign_status: :getstatus,
-        campaign_hold: :holdsms,
-        campaign_release: :releasesms
-      }[method]
+    before { allow(rest_client).to receive(:get).and_return({}) }
 
-      allow(rest_client).to receive(:get).and_return({})
+    it '#campaign_status' do
+      client.campaign_status '12345'
 
-      client.send method, '12345'
-
-      expect(rest_client).to have_received(:get).once.with(rest_method, id: '12345')
+      expect(rest_client).to have_received(:get).once.with(:getstatus, id: '12345')
     end
 
-    it { check_for :campaign_status  }
-    it { check_for :campaign_hold    }
-    it { check_for :campaign_release }
+    it '#campaign_hold' do
+      client.campaign_hold '12345'
+
+      expect(rest_client).to have_received(:get).once.with(:holdsms, id: '12345')
+    end
+
+    it '#campaign_release' do
+      client.campaign_release '12345'
+
+      expect(rest_client).to have_received(:get).once.with(:releasesms, id: '12345')
+    end
 
     it 'has tests to cover campaign_status csv result'
   end

--- a/spec/lib/locasms/client_spec.rb
+++ b/spec/lib/locasms/client_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe LocaSMS::Client do # rubocop:disable RSpec/FilePath
   subject(:client) { described_class.new :login, :password, rest_client: rest_client, callback: nil }
 
-  let(:rest_client) { instance_double 'RestClient' }
+  let(:rest_client) { instance_double LocaSMS::RestClient }
   let(:base_args) { { msg: 'given message', numbers: '11988889991,11988889992,11988889993' } }
   let(:default_callback_args) { base_args.merge(url_callback: 'default') }
   let(:some_callback_args) { base_args.merge(url_callback: 'something') }

--- a/spec/lib/locasms/helpers/date_time_helper_spec.rb
+++ b/spec/lib/locasms/helpers/date_time_helper_spec.rb
@@ -6,16 +6,33 @@ describe LocaSMS::Helpers::DateTimeHelper do # rubocop:disable RSpec/FilePath
   subject(:helper) { described_class }
 
   describe '.parse' do
+    subject { described_class.parse(value) }
+
     let(:expected) { Time.parse '1977-03-14 14:12:00' }
 
-    def try_for(value)
-      helper.parse(value) == expected
+    context 'when is a date time' do
+      let(:value) { DateTime.parse '1977-03-14 14:12:00' }
+
+      it { is_expected.to eq expected }
     end
 
-    it { try_for DateTime.parse('1977-03-14 14:12:00') }
-    it { try_for Time.parse('1977-03-14 14:12:00') }
-    it { try_for '1977-03-14 14:12:00' }
-    it { try_for 227_207_520 }
+    context 'when is a time' do
+      let(:value) { Time.parse '1977-03-14 14:12:00' }
+
+      it { is_expected.to eq expected }
+    end
+
+    context 'when is a string' do
+      let(:value) { '1977-03-14 14:12:00' }
+
+      it { is_expected.to eq expected }
+    end
+
+    context 'when is a number' do
+      let(:value) { 227_196_720 }
+
+      it { is_expected.to eq expected }
+    end
   end
 
   describe '.split' do

--- a/spec/lib/locasms/rest_client_spec.rb
+++ b/spec/lib/locasms/rest_client_spec.rb
@@ -26,7 +26,7 @@ describe LocaSMS::RestClient do # rubocop:disable RSpec/FilePath
     it 'performs get request to url with parameters' do
       allow(Net::HTTP)
         .to receive(:get_response)
-        .and_return(OpenStruct.new(body: body))
+        .and_return(instance_double(Net::HTTPOK, body: body))
 
       rest_client.get(action, params)
 


### PR DESCRIPTION
- [x] bumps rubocop from 1.22 to 1.36;
- [x] bumps rubocop-performance from 1.11 to 1.15;
- [x] bumps rubocop-rspec from 2.5 to 2.13;
- [x] fixes some news rules
  - [x] RSpec/VerifiedDoubles
  - [x] Gemspec/DeprecatedAttributeAssignment
  - [x] RSpec/VerifiedDoubleReference
  - [x] RSpec/NoExpectationExample
- [x] Fixes spec without correct expectations
- [x] removes ruby 2.5 from tests