### PR TITLE
chore(deps): bumps some development extensions

### DIFF
--- a/locasms.gemspec
+++ b/locasms.gemspec
@@ -28,14 +28,14 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake',      '~> 13.0'
 
   # test stuff
-  spec.add_development_dependency 'rspec',     '~> 3.9'
+  spec.add_development_dependency 'rspec',     '~> 3.11'
   spec.add_development_dependency 'timecop',   '~> 0.9'
 
   # for documentation
   spec.add_development_dependency 'yard',      '~> 0.9'
 
   # for code coverage
-  spec.add_development_dependency 'simplecov', '~> 0.18'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
 
   # for code quality
   spec.add_development_dependency 'rubocop', '~> 1.36'


### PR DESCRIPTION
- rspec from 3.9 to 3.11;
- simplecov from 0.18 to 0.21;